### PR TITLE
using $koshu_param_taskfile everywhere instead of hard-coded path

### DIFF
--- a/src/koshu.sh
+++ b/src/koshu.sh
@@ -230,8 +230,8 @@ function koshu_bootstrap () {
   koshu_set_here
 
   # import koshufile
-  chmod +xrw "./koshufile"
-  . "./koshufile" --source-only
+  chmod +xrw "$koshu_param_taskfile"
+  . "$koshu_param_taskfile" --source-only
 
   # variable must be set after importing koshufile
   koshu_functions=($(declare -F | sed 's/declare -f //g'))


### PR DESCRIPTION
I wasn't able to use a different path to koshufile with the error

```
chmod: ./koshufile: No such file or directory
[koshu] An unhandled error occured.
[koshu] Exit code: 1
```

this fix removes hard-coded paths to "./koshufile" and replaces them with the variable

tests passing